### PR TITLE
Disable blockstore ARC cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@ ENV GO111MODULE=on
 
 WORKDIR /go-ipfs
 
+COPY build/disable-blockstore-arc-cache.patch /patches/
+
 RUN git clone https://github.com/ipfs/go-ipfs . && \
-    git checkout v0.12.2
+    git checkout v0.12.2 && \
+    # Apply a patch for disabling the blockstore ARC cache
+    git apply /patches/disable-blockstore-arc-cache.patch
 
 COPY . /go-ipfs/ipfs-go-ds-storj
 

--- a/build/disable-blockstore-arc-cache.patch
+++ b/build/disable-blockstore-arc-cache.patch
@@ -1,0 +1,13 @@
+diff --git a/core/node/groups.go b/core/node/groups.go
+index 8036715..468662e 100644
+--- a/core/node/groups.go
++++ b/core/node/groups.go
+@@ -182,6 +182,8 @@
+ 		cacheOpts.HasBloomFilterSize = 0
+ 	}
+ 
++	cacheOpts.HasARCCacheSize = 0
++
+ 	finalBstore := fx.Provide(GcBlockstoreCtor)
+ 	if cfg.Experimental.FilestoreEnabled || cfg.Experimental.UrlstoreEnabled {
+ 		finalBstore = fx.Provide(FilestoreBlockstoreCtor)


### PR DESCRIPTION
There is no config to disable the ARC cache. So a patch is applied to the Docker build to disable it.