### PR TITLE
Do not enable kv.rangefeed.enabled cluster setting on CockroachDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Docker images are published to https://hub.docker.com/r/storjlabs/ipfs-go-ds-sto
 
 `IPFS_BLOOM_FILTER_SIZE` sets the size in bytes of the datastore bloom filter. It is recommended to set this on production installations for reducing the number of calls to the database due to incoming requests from the IPFS network. Default value is 0, which means that the bloom filter is disabled. Details in https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#datastorebloomfiltersize.
 
-`STORJ_UPDATE_BLOOM_FILTER` enables the bloom filter updater, which listens to changes in the local database and updates the datastore bloom filter. The default value is false. It should be enabled when running multiple nodes attached to the same datastore. Only CockroachDB is supported.
+`STORJ_UPDATE_BLOOM_FILTER` enables the bloom filter updater, which listens to changes in the local database and updates the datastore bloom filter. The default value is false. It should be enabled when running multiple nodes attached to the same datastore. Only CockroachDB is supported. The `kv.rangefeed.enabled` cluster setting on CockroachDB must be set to `true`. See https://www.cockroachlabs.com/docs/v21.2/changefeed-for.html#create-a-changefeed.
 
 `STORJ_PACK_INTERVAL` can be set to change the packing interval. The default packing interval is 1 minute. If set to a negative duration, e.g. `-1m`, the packing job is disabled.
 

--- a/bloom/updater.go
+++ b/bloom/updater.go
@@ -86,12 +86,6 @@ func (updater *Updater) listen(ctx context.Context, cursor time.Time) (err error
 	}
 	defer db.Close()
 
-	// Required for the proper execution of the changefeed
-	_, err = db.Exec(ctx, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-	if err != nil {
-		return Error.New("failed to enable kv.rangefeed.enabled cluster setting: %s", err)
-	}
-
 	dbCreatedTime, err := db.GetCreatedTime(ctx)
 	if err != nil {
 		return Error.Wrap(err)

--- a/bloom/updater_test.go
+++ b/bloom/updater_test.go
@@ -26,6 +26,10 @@ func TestBloomUpdater(t *testing.T) {
 			t.Skipf("%s not supported", tempDB.Implementation)
 		}
 
+		// Required for the proper execution of the changefeed
+		_, err := db.Exec(ctx, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+		require.NoError(t, err)
+
 		bf, err := bbloom.New(float64(1024), float64(7))
 		require.NoError(t, err)
 


### PR DESCRIPTION
The `kv.rangefeed.enabled` cluster setting must be enabled for the proper function of the changefeed. But cluster settings can be set only by an admin user. So we should not do this in the bloom updater code but execute it manually on the CockroachDB instance.