### PR TITLE
Env vars to preserve identity between Docker runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ docker run --rm -d \
     -e STORJ_DATABASE_URL=<database_url> \
     -e STORJ_BUCKET=<storj_bucket> \
     -e STORJ_ACCESS=<storj_access_grant> \
+    -e IPFS_IDENTITY_PEER_ID=<peer_id> \
+    -e IPFS_IDENTITY_PRIVATE_KEY=<escaped_privkey> \
     -e IPFS_GATEWAY_NO_FETCH=true \
     -e IPFS_GATEWAY_DOMAIN=<gateway_domain_name> \
     -e IPFS_GATEWAY_USE_SUBDOMAINS=false \
@@ -117,6 +119,10 @@ Docker images are published to https://hub.docker.com/r/storjlabs/ipfs-go-ds-sto
 `STORJ_BUCKET` must be set to an existing bucket.
 
 `STORJ_ACCESS` must be set to an access grant with full permission to `STORJ_BUCKET`.
+
+`IPFS_IDENTITY_PEER_ID` can be set optionally to preserve the node identity between runs. The current peer ID can be found under `Identity.PeerID` in the config file.
+
+`IPFS_IDENTITY_PRIVATE_KEY` must be set if `IPFS_IDENTITY_PEER_ID` is set, and the provided private key must match the peer ID. The current private key can be found under `Identity.PrivKey` in the config file. The provided private key must be properly escaped for the `sed` tool, i.e. it must be wrapped with quotation marks and slashes must be escaped with backslashes.
 
 `IPFS_GATEWAY_NO_FETCH` determines if the IPFS gateway is open (if set to false) or restricted (if set to true). Restricted gateways serve files only from the local IPFS node. Open gateways search the IPFS network if the file is not present on the local IPFS node.
 

--- a/docker/container_daemon
+++ b/docker/container_daemon
@@ -23,6 +23,17 @@ else
   esac
   ipfs init --empty-repo $INIT_ARGS
 
+  # Set the node's peer ID, if a predefined one is provided
+  if [ ! -z $IPFS_IDENTITY_PEER_ID ]; then
+    ipfs config Identity.PeerID $IPFS_IDENTITY_PEER_ID
+  fi
+
+  # Set the private key that matches the peer ID, if provided above
+  if [ ! -z $IPFS_IDENTITY_PRIVATE_KEY ]; then
+    # We use sed here because `ipfs config` does not allow changing the PrivKey.
+    sed -i "s/\(\"PrivKey\": \)\(.*\)/\1\"$IPFS_IDENTITY_PRIVATE_KEY\"/" $repo/config
+  fi
+
   # HTTP API port config
   if [ -z $IPFS_API_PORT ]; then IPFS_API_PORT=5001; fi
   ipfs config Addresses.API /ip4/0.0.0.0/tcp/$IPFS_API_PORT

--- a/docker/container_daemon
+++ b/docker/container_daemon
@@ -31,7 +31,7 @@ else
   # Set the private key that matches the peer ID, if provided above
   if [ ! -z $IPFS_IDENTITY_PRIVATE_KEY ]; then
     # We use sed here because `ipfs config` does not allow changing the PrivKey.
-    sed -i "s/\(\"PrivKey\": \)\(.*\)/\1\"$IPFS_IDENTITY_PRIVATE_KEY\"/" $repo/config
+    sed -i "s/\(\"PrivKey\": \).*/\1\"$IPFS_IDENTITY_PRIVATE_KEY\"/" $repo/config
   fi
 
   # HTTP API port config


### PR DESCRIPTION
The new IPFS_IDENTITY_PEER_ID and IPFS_IDENTITY_PRIVATE_KEY env vars override the auto-generated identity of the node. They must be both set and the private key must match the peer ID.