### PR TITLE
Store provider records in separate LevelDB datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,38 @@ The `config` file should include the following:
   "Datastore": {
   ...
     "Spec": {
-      "child": {
-        "type": "storjds",
-        "dbURI": "$databaseURI",
-        "bucket": "$bucketname",
-        "accessGrant": "$accessGrant",
-        "packInterval": "$packInterval",
-        "debugAddr": "$debugAddr",
-        "updateBloomFilter": "$updateBloomFilter"
-      },
-      "prefix": "storj.datastore",
-      "type": "measure"
+      "mounts": [
+        {
+          "child": {
+            "type": "storjds",
+            "dbURI": "$databaseURI",
+            "bucket": "$bucketname",
+            "accessGrant": "$accessGrant",
+            "packInterval": "$packInterval",
+            "debugAddr": "$debugAddr",
+            "updateBloomFilter": "$updateBloomFilter"
+          },
+          "mountpoint": "/",
+          "prefix": "storj.datastore",
+          "type": "measure"
+        },
+        {
+          "child": {
+            "compression": "none",
+            "path": "providers",
+            "type": "levelds"
+          },
+          "mountpoint": "/providers",
+          "prefix": "leveldb.datastore",
+          "type": "measure"
+        }
+      ],
+      "type": "mount"
     }
+    ...
+  }
   ...
+}
 ```
 `$databaseURI` is the URI to a Postgres or CockroachDB database installation. This database is used for local caching of blocks before they are packed and uploaded to the Storj bucket. The database must exists. 
 
@@ -82,7 +101,7 @@ The `config` file should include the following:
 If you are configuring a brand new ipfs instance without any data, you can overwrite the `datastore_spec` file with:
 
 ```json
-{"bucket":"$bucketname"}
+{"mounts":[{"mountpoint":"/providers","path":"providers","type":"levelds"},{"bucket":"$bucketname","mountpoint":"/"}],"type":"mount"}
 ```
 
 Otherwise, you need to do a datastore migration.
@@ -109,7 +128,7 @@ docker run --rm -d \
     -e GOLOG_FILE=/app/log/output.log \
     -e GOLOG_LOG_LEVEL="storjds=info" \
     --mount type=bind,source=<log-dir>,destination=/app/log \
-    storjlabs/ipfs-go-ds-storj
+    storjlabs/ipfs-go-ds-storj:<tag>
 ```
 
 Docker images are published to https://hub.docker.com/r/storjlabs/ipfs-go-ds-storj.

--- a/docker/container_daemon
+++ b/docker/container_daemon
@@ -59,8 +59,8 @@ else
   # Storj datastore config
   if [ ! -z $STORJ_PACK_INTERVAL ]; then CFG_PACK_INTERVAL=",\"packInterval\": \"$STORJ_PACK_INTERVAL\""; fi
   if [ -z $STORJ_UPDATE_BLOOM_FILTER ]; then STORJ_UPDATE_BLOOM_FILTER=false; fi
-  ipfs config --json Datastore.Spec "{\"child\":{\"type\": \"storjds\",\"dbURI\": \"$STORJ_DATABASE_URL\",\"bucket\": \"$STORJ_BUCKET\",\"accessGrant\": \"$STORJ_ACCESS\"$CFG_PACK_INTERVAL,\"debugAddr\": \"$STORJ_DEBUG_ADDR\",\"updateBloomFilter\": \"$STORJ_UPDATE_BLOOM_FILTER\"},\"prefix\": \"storj.datastore\",\"type\": \"measure\"}"
-  echo -e "{\"bucket\":\"$STORJ_BUCKET\"}" > $repo/datastore_spec
+  ipfs config --json Datastore.Spec "{\"mounts\": [{\"child\": {\"type\": \"storjds\",\"dbURI\": \"$STORJ_DATABASE_URL\",\"bucket\": \"$STORJ_BUCKET\",\"accessGrant\": \"$STORJ_ACCESS\"$CFG_PACK_INTERVAL,\"debugAddr\": \"$STORJ_DEBUG_ADDR\",\"updateBloomFilter\": \"$STORJ_UPDATE_BLOOM_FILTER\"},\"mountpoint\": \"/\",\"prefix\": \"storj.datastore\",\"type\": \"measure\"},{\"child\": {\"compression\": \"none\",\"path\": \"providers\",\"type\": \"levelds\"},\"mountpoint\": \"/providers\",\"prefix\": \"leveldb.datastore\",\"type\": \"measure\"}],\"type\": \"mount\"}"
+  echo -e "{\"mounts\":[{\"mountpoint\":\"/providers\",\"path\":\"providers\",\"type\":\"levelds\"},{\"bucket\":\"$STORJ_BUCKET\",\"mountpoint\":\"/\"}],\"type\":\"mount\"}" > $repo/datastore_spec
 
   # Set up the swarm key, if provided
 

--- a/plugin/storjds.go
+++ b/plugin/storjds.go
@@ -186,21 +186,42 @@ func (plugin *StorjPlugin) Start(node *core.IpfsNode) error {
 }
 
 func lookupStorjDatastoreSpec(spec map[string]interface{}) map[string]interface{} {
-	which, ok := spec["type"].(string)
+	mounts, ok := spec["mounts"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, iface := range mounts {
+		mount, ok := iface.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		storjds := lookupStorjDatastoreSpecFromMount(mount)
+		if storjds != nil {
+			return storjds
+		}
+	}
+
+	return nil
+}
+
+func lookupStorjDatastoreSpecFromMount(mount map[string]interface{}) map[string]interface{} {
+	which, ok := mount["type"].(string)
 	if !ok {
 		return nil
 	}
 
 	if which == "storjds" {
-		return spec
+		return mount
 	}
 
-	child, ok := spec["child"].(map[string]interface{})
+	child, ok := mount["child"].(map[string]interface{})
 	if !ok {
 		return nil
 	}
 
-	return lookupStorjDatastoreSpec(child)
+	return lookupStorjDatastoreSpecFromMount(child)
 }
 
 func (plugin *StorjPlugin) Close() error {


### PR DESCRIPTION
This PR configures the Docker image to store the provider records in a local LevelDB datastore.

The DHT provider records (keys starting with the `/providers` prefix) are currently overwhelming the database with millions of records in the `datastore` table. Queries running on the table take a lot of time and block other goroutines, resulting in OOM kills over time.

We don't need to persist these records as they can be rebuilt from the network if the IPFS node restarts. Thus we can store these records in a separate local LevelDB datastore.