### PR TITLE
Optimize indexes

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -106,6 +106,16 @@ func (db *DB) Migration() *migrate.Migration {
 					`CREATE INDEX IF NOT EXISTS blocks_size_created_status_index ON blocks ( size, created, pack_status )`,
 				},
 			},
+			{
+				DB:          &db.DB,
+				Description: "Improve indexes",
+				Version:     2,
+				Action: migrate.SQL{
+					`DROP INDEX IF EXISTS blocks_size_created_status_index`,
+					`CREATE INDEX IF NOT EXISTS blocks_pack_status_index ON blocks ( pack_status ) STORING ( size, created )`,
+					`CREATE INDEX IF NOT EXISTS blocks_deleted_false_index ON blocks ( deleted ) WHERE deleted = false`,
+				},
+			},
 		},
 	}
 }

--- a/db/db.go
+++ b/db/db.go
@@ -112,7 +112,7 @@ func (db *DB) Migration() *migrate.Migration {
 				Version:     2,
 				Action: migrate.SQL{
 					`DROP INDEX IF EXISTS blocks_size_created_status_index`,
-					`CREATE INDEX IF NOT EXISTS blocks_pack_status_index ON blocks ( pack_status ) STORING ( size, created )`,
+					`CREATE INDEX IF NOT EXISTS blocks_pack_status_index ON blocks ( pack_status ) INCLUDE ( size, created )`,
 					`CREATE INDEX IF NOT EXISTS blocks_deleted_false_index ON blocks ( deleted ) WHERE deleted = false`,
 				},
 			},


### PR DESCRIPTION
The existing `blocks_size_created_status` index did not work well with packing queries, so it is replaced by `blocks_pack_status_index`, which proved to work better after some experiments.

In addition, we are adding `blocks_deleted_false_index` to optimize some queries that select blocks that have not been deleted yet.