### PR TITLE
Rename Run methods to Start

### DIFF
--- a/block/store.go
+++ b/block/store.go
@@ -60,7 +60,7 @@ func (store *Store) Sync(ctx context.Context, prefix ds.Key) (err error) {
 	defer mon.Task()(&ctx)(&err)
 
 	// Run the packer in a separate context to avoid canceling it prematurely.
-	store.packer.Run(context.Background())
+	store.packer.Start(context.Background())
 
 	return nil
 }

--- a/bloom/updater.go
+++ b/bloom/updater.go
@@ -18,6 +18,7 @@ import (
 	"github.com/zeebo/errs"
 	"go.uber.org/zap"
 
+	"storj.io/common/sync2"
 	"storj.io/ipfs-go-ds-storj/db"
 )
 
@@ -44,7 +45,7 @@ func NewUpdater(dbURI string, bloom *bbloom.Bloom) *Updater {
 	}
 }
 
-func (updater *Updater) Run(ctx context.Context) {
+func (updater *Updater) Start(ctx context.Context) {
 	defer mon.Task()(&ctx)(nil)
 
 	updater.runOnce.Do(func() {
@@ -61,7 +62,7 @@ func (updater *Updater) Run(ctx context.Context) {
 				default:
 					if err != nil {
 						log.Desugar().Error("Bloom filter updater error", zap.Error(err))
-						time.Sleep(1 * time.Second)
+						sync2.Sleep(ctx, 1*time.Second)
 					}
 					err = updater.listen(ctx, time.Now().Add(-1*time.Minute))
 				}

--- a/bloom/updater_test.go
+++ b/bloom/updater_test.go
@@ -32,7 +32,7 @@ func TestBloomUpdater(t *testing.T) {
 		updater := bloom.NewUpdater(tempDB.ConnStr, bf)
 		defer ctx.Check(updater.Close)
 
-		updater.Run(ctx)
+		updater.Start(ctx)
 
 		b58Hash := "QmVAXDpe8PKRxScTdZ6nMYpBVwU9EV5CwefQhyBVrWPvzb"
 		multihash, err := mh.FromB58String(b58Hash)

--- a/pack/chore.go
+++ b/pack/chore.go
@@ -76,7 +76,7 @@ func (chore *Chore) WithPackSize(minSize, maxSize, maxBlocks int) *Chore {
 	return chore
 }
 
-func (chore *Chore) Run(ctx context.Context) {
+func (chore *Chore) Start(ctx context.Context) {
 	defer mon.Task()(&ctx)(nil)
 
 	chore.runOnce.Do(func() {

--- a/plugin/storjds.go
+++ b/plugin/storjds.go
@@ -180,7 +180,7 @@ func (plugin *StorjPlugin) Start(node *core.IpfsNode) error {
 	}
 
 	plugin.bloomUpdater = bloom.NewUpdater(storj.cfg.DBURI, bloomFilter)
-	plugin.bloomUpdater.Run(node.Context())
+	plugin.bloomUpdater.Start(node.Context())
 
 	return nil
 }


### PR DESCRIPTION
This makes it clear that the method start a job and does not wait for it to finish.

Also one instance of time.Sleep is replaced with sync2.Sleep, so it can be canceled with the context.